### PR TITLE
Change how Logging is implemented

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ OPENAI_API_KEY=your-openai-api-key
 # MAX_RETRIES=3
 # RETRY_DELAY=1000
 # MAX_CONNECTIONS=100
-# LOG_LEVEL=INFO
+# LOG_LEVEL=info
 
 # MCP Transport configuration
 # MCP_TRANSPORT=stdio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ We welcome contributions to the Nutrient Document Engine MCP Server! This docume
 
    # Optional configuration
    MCP_TRANSPORT=stdio
-   LOG_LEVEL=INFO
+   LOG_LEVEL=info
    ```
 
 ### Starting Document Engine

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,18 +13,18 @@ This guide covers configuration options, environment variables, transport modes,
 
 ### Optional Configuration
 
-| Variable             | Description                                                               | Default                         | Example    |
-|----------------------|---------------------------------------------------------------------------|---------------------------------|------------|
-| `MCP_TRANSPORT`      | Transport type - "stdio" or "http"                                        | `stdio`                         | `http`     |
-| `MCP_HOST`           | The host as IP address for the Dashboard and the MCP server and Dashboard | `localhost`                     | `0.0.0.0`  |
-| `PORT`               | HTTP server port (HTTP transport only)                                    | `5100`                          | `8080`     |
-| `MAX_RETRIES`        | Number of API request retries                                             | `3`                             | `5`        |
-| `CONNECTION_TIMEOUT` | Request timeout in milliseconds                                           | `30000`                         | `60000`    |
-| `RETRY_DELAY`        | Delay between retries in milliseconds                                     | `1000`                          | `2000`     |
-| `MAX_CONNECTIONS`    | Maximum concurrent connections                                            | `100`                           | `200`      |
-| `LOG_LEVEL`          | Logging level                                                             | `INFO`                          | `DEBUG`    |
-| `DASHBOARD_USERNAME` | Dashboard authentication username (required to enable dashboard)          | `undefined`                     | `admin`    |
-| `DASHBOARD_PASSWORD` | Dashboard authentication password (required to enable dashboard)          | `undefined`                     | `password` |
+| Variable             | Description                                                                                     | Default     | Example    |
+|----------------------|-------------------------------------------------------------------------------------------------|-------------|------------|
+| `MCP_TRANSPORT`      | Transport type - "stdio" or "http"                                                              | `stdio`     | `http`     |
+| `MCP_HOST`           | The host as IP address for the Dashboard and the MCP server and Dashboard                       | `localhost` | `0.0.0.0`  |
+| `PORT`               | HTTP server port (HTTP transport only)                                                          | `5100`      | `8080`     |
+| `MAX_RETRIES`        | Number of API request retries                                                                   | `3`         | `5`        |
+| `CONNECTION_TIMEOUT` | Request timeout in milliseconds                                                                 | `30000`     | `60000`    |
+| `RETRY_DELAY`        | Delay between retries in milliseconds                                                           | `1000`      | `2000`     |
+| `MAX_CONNECTIONS`    | Maximum concurrent connections                                                                  | `100`       | `200`      |
+| `LOG_LEVEL`          | Logging level ("debug", "info", "notice", "warning", "error", "critical", "alert", "emergency") | `info`      | `error`    |
+| `DASHBOARD_USERNAME` | Dashboard authentication username (required to enable dashboard)                                | `undefined` | `admin`    |
+| `DASHBOARD_PASSWORD` | Dashboard authentication password (required to enable dashboard)                                | `undefined` | `password` |
 
 > MCP_HOST information
 >  Setting host to `127.0.0.1` (localhost) ensure that the Dashboard and the MCP server is only accessible locally 
@@ -275,5 +275,5 @@ echo $DOCUMENT_ENGINE_API_AUTH_TOKEN
 
 ### Debug Logging
 ```bash
-LOG_LEVEL=DEBUG npx @nutrient-sdk/document-engine-mcp-server
+LOG_LEVEL=debug npx @nutrient-sdk/document-engine-mcp-server
 ```

--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -69,7 +69,7 @@ export async function createDocumentEngineClient(config: ClientConfig): Promise<
 function setupInterceptors(client: Client): void {
   client.interceptors.request.use(
     config => {
-      logger.request(config.method || 'unknown', config.url || 'unknown', {
+      logger.request(null, config.method || 'unknown', config.url || 'unknown', {
         params: config.params,
         body: config.data,
       });
@@ -82,7 +82,7 @@ function setupInterceptors(client: Client): void {
 
   client.interceptors.response.use(
     response => {
-      logger.response(response.status, response.config?.url || 'unknown', {
+      logger.response(null, response.status, response.config?.url || 'unknown', {
         data: response.data,
       });
       return response;
@@ -93,7 +93,7 @@ function setupInterceptors(client: Client): void {
         const method = error.config?.method?.toUpperCase();
         const url = error.config?.url || 'unknown';
 
-        logger.error('API Request Failed', {
+        logger.error(null, 'API Request Failed', {
           method,
           url,
           status,
@@ -101,7 +101,7 @@ function setupInterceptors(client: Client): void {
           code: error.code,
         });
       } else {
-        logger.error('Non-Axios Error in Response Interceptor', {
+        logger.error(null, 'Non-Axios Error in Response Interceptor', {
           message: error instanceof Error ? error.message : String(error),
         });
       }
@@ -139,7 +139,7 @@ function addRetryFunctionality(client: Client, maxRetries: number, retryDelay: n
             const currentAttempt = retryCount + 1;
             const delay = calculateDelay(retryDelay, retryCount);
 
-            logger.retry(currentAttempt, maxRetries, delay);
+            logger.retry(null, currentAttempt, maxRetries, delay);
             await new Promise(resolve => setTimeout(resolve, delay));
             return attempt(retryCount + 1);
           }

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -52,7 +52,7 @@ export async function dashboardHandler(client: DocumentEngineClient, req: Reques
     // Render HTML dashboard
     res.send(dashboardTemplate(documents, formatFileSize, message));
   } catch (error) {
-    logger.error('Dashboard error', { error });
+    logger.error(null, 'Dashboard error', { error });
     res
       .status(500)
       .send(
@@ -128,7 +128,7 @@ export async function uploadHandler(client: DocumentEngineClient, req: Request, 
     // Render upload results
     res.send(uploadResultsTemplate(templateResults));
   } catch (error) {
-    logger.error('File upload error', { error });
+    logger.error(null, 'File upload error', { error });
     res
       .status(500)
       .send(
@@ -173,7 +173,7 @@ export async function downloadHandler(client: DocumentEngineClient, req: Request
 
     res.send(Buffer.from(response.data));
   } catch (error) {
-    logger.error('Document download error', { error });
+    logger.error(null, 'Document download error', { error });
     res
       .status(500)
       .send(
@@ -201,7 +201,7 @@ export async function deleteHandler(client: DocumentEngineClient, req: Request, 
     // Redirect back to dashboard with success message
     res.redirect('/dashboard?message=Document+deleted+successfully');
   } catch (error) {
-    logger.error('Document delete error', { error });
+    logger.error(null, 'Document delete error', { error });
     res
       .status(500)
       .send(

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -17,7 +17,9 @@ const environmentSchema = z.object({
   MAX_RETRIES: z.coerce.number().int().min(0).default(3),
   RETRY_DELAY: z.coerce.number().int().min(0).default(1000),
   MAX_CONNECTIONS: z.coerce.number().int().positive().default(100),
-  LOG_LEVEL: z.enum(['ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG']).default('INFO'),
+  LOG_LEVEL: z
+    .enum(['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'])
+    .default('info'),
 
   // MCP Transport configuration
   MCP_TRANSPORT: z.enum(['stdio', 'http']).default('stdio'),

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -13,181 +13,160 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getEnvironment } from './Environment.js';
-import * as process from 'node:process';
-
-export enum LogLevel {
-  ERROR = 0,
-  WARNING = 1,
-  INFO = 2,
-  DEBUG = 3,
-}
 
 // MCP standard logging levels
 type MCPLogLevel = z.infer<typeof LoggingMessageNotificationSchema.shape.params.shape.level>;
 
-interface LogEntry {
-  timestamp: string;
-  level: string;
-  message: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  context?: any;
-}
+const LogLevel: Record<MCPLogLevel, number> = {
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  critical: 5,
+  alert: 6,
+  emergency: 7,
+};
+
+type TransportType = 'stdio' | 'http' | 'sse';
 
 class Logger {
-  private logLevel: LogLevel;
   private serviceName: string;
-  private mcpServer: McpServer | null = null;
-
-  constructor(serviceName: string = 'document-engine-mcp') {
-    this.serviceName = serviceName;
-
-    // Parse log level from validated environment
-    try {
-      const env = getEnvironment();
-      switch (env.LOG_LEVEL) {
-        case 'ERROR':
-          this.logLevel = LogLevel.ERROR;
-          break;
-        case 'WARN':
-        case 'WARNING':
-          this.logLevel = LogLevel.WARNING;
-          break;
-        case 'INFO':
-          this.logLevel = LogLevel.INFO;
-          break;
-        case 'DEBUG':
-          this.logLevel = LogLevel.DEBUG;
-          break;
-        default:
-          this.logLevel = LogLevel.INFO;
-      }
-    } catch {
-      // If environment validation fails, use default log level
-      this.logLevel = LogLevel.INFO;
-    }
-  }
+  private serverLogLevel: MCPLogLevel;
+  private transportType: TransportType;
 
   /**
-   * Set the MCP server instance to enable client logging
+   * Constructor for initializing an instance with the specified service name, transport type, and server log level.
+   *
+   * @param {string} serviceName - The name of the service.
+   * @param {TransportType} [transportType="stdio"] - The transport type for the server.
+   * @param {MCPLogLevel} [serverLogLevel="info"] - The logging level for the server (this is different from client log level. Defaults to "info" if not specified.
+   * @return {void}
    */
-  setMCPServer(server: McpServer | null): void {
-    this.mcpServer = server;
+  constructor(
+    serviceName: string,
+    transportType: TransportType = 'stdio',
+    serverLogLevel: MCPLogLevel = 'info'
+  ) {
+    this.serviceName = serviceName;
+    this.transportType = transportType;
+    this.serverLogLevel = serverLogLevel;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  private formatLogEntry(level: string, message: string, context?: any): string {
-    const entry: LogEntry = {
-      timestamp: new Date().toISOString(),
-      level,
-      message: `[${this.serviceName}] ${message}`,
-    };
+  private shouldServerLog(logLevel: MCPLogLevel) {
+    return LogLevel[this.serverLogLevel] <= LogLevel[logLevel];
+  }
 
+  private formatLogEntry(level: string, message: string, context?: unknown): string {
+    let log = `[${level.toUpperCase()}] - (${this.serviceName}) - ${new Date().toISOString()} : ${message}`;
     if (context !== undefined) {
-      entry.context = context;
+      log += ` ${JSON.stringify(context)}`;
     }
-
-    return JSON.stringify(entry);
+    return log;
   }
 
-  private shouldLog(level: LogLevel): boolean {
-    return level <= this.logLevel;
-  }
-
-  private writeLog(
-    level: MCPLogLevel,
-    stderrLevel: string,
-    message: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-    context?: any
-  ): void {
-    const logLine = this.formatLogEntry(stderrLevel, message, context);
-    const env = getEnvironment();
-    const isServerConnected = this.mcpServer?.isConnected();
-    const isStdIOMode = env.MCP_TRANSPORT === 'stdio';
+  writeLog(logLevel: MCPLogLevel, mcpServer: McpServer | null, message: string, context?: unknown) {
+    const isServerConnected = mcpServer?.isConnected();
+    const isStdIOMode = this.transportType === 'stdio';
 
     // Send to server notifications when connected
     if (isServerConnected) {
       const params: LoggingMessageNotification['params'] = {
-        level,
+        level: logLevel,
         data: `[${this.serviceName}] ${message}`,
       };
 
       try {
-        this.mcpServer!.server.sendLoggingMessage(params);
+        mcpServer!.server.sendLoggingMessage(params);
       } catch {
         // Fall through to console fallback if notification fails
       }
     }
 
-    // Console output handling based on mode and connection status
-    if (isStdIOMode) {
-      if (!isServerConnected) {
-        process.stderr.write(logLine + '\n');
-      }
-    } else {
-      // HTTP mode: write to stderr for errors, stdout for other log levels
-      if (level === 'error') {
+    if (this.shouldServerLog(logLevel)) {
+      const logLine = this.formatLogEntry(logLevel, message, context);
+      // Console output handling based on mode and connection status
+      if (isStdIOMode) {
         process.stderr.write(logLine + '\n');
       } else {
-        process.stdout.write(logLine + '\n');
+        // HTTP mode: write to stderr for errors, stdout for other log levels
+        if (['warning', 'error', 'critical', 'alert', 'emergency'].includes(logLevel)) {
+          process.stderr.write(logLine + '\n');
+        } else {
+          process.stdout.write(logLine + '\n');
+        }
       }
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  error(message: string, context?: any): void {
-    if (!this.shouldLog(LogLevel.ERROR)) return;
-
-    this.writeLog('error', 'ERROR', message, context);
+  // Tier 1 convenience methods
+  debug(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('debug', mcpServer, message, context);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  warn(message: string, context?: any): void {
-    if (this.shouldLog(LogLevel.WARNING)) {
-      this.writeLog('warning', 'WARNING', message, context);
+  info(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('info', mcpServer, message, context);
+  }
+
+  notice(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('notice', mcpServer, message, context);
+  }
+
+  warning(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('warning', mcpServer, message, context);
+  }
+
+  error(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('error', mcpServer, message, context);
+  }
+
+  critical(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('critical', mcpServer, message, context);
+  }
+
+  alert(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('alert', mcpServer, message, context);
+  }
+
+  emergency(mcpServer: McpServer | null, message: string, context?: unknown) {
+    this.writeLog('emergency', mcpServer, message, context);
+  }
+
+  // Tier 2 convenience methods
+  request(mcpServer: McpServer | null, method: string, url: string, context?: unknown): void {
+    const message = `Request: ${method?.toUpperCase()} ${url}`;
+    if (this.serverLogLevel === 'debug') {
+      this.debug(mcpServer, message, context);
+    } else {
+      this.info(mcpServer, message);
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  info(message: string, context?: any): void {
-    if (this.shouldLog(LogLevel.INFO)) {
-      this.writeLog('info', 'INFO', message, context);
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  debug(message: string, context?: any): void {
-    if (this.shouldLog(LogLevel.DEBUG)) {
-      this.writeLog('debug', 'DEBUG', message, context);
-    }
-  }
-
-  // Convenience methods for common logging patterns
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  request(method: string, url: string, context?: any): void {
-    this.info(`Request: ${method?.toUpperCase()} ${url}`, context);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  response(status: number, url: string, context?: any): void {
-    const level = status >= 400 ? LogLevel.ERROR : LogLevel.INFO;
+  response(mcpServer: McpServer | null, status: number, url: string, context?: unknown): void {
     const message = `Response: ${status} ${url}`;
 
-    if (level === LogLevel.ERROR) {
-      this.error(message, context);
+    if (status >= 400) {
+      this.error(mcpServer, message, context);
+    } else if (this.serverLogLevel === 'debug') {
+      this.debug(mcpServer, message, context);
     } else {
-      this.info(message, context);
+      this.info(mcpServer, message);
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Context can be any type of metadata
-  retry(attempt: number, maxRetries: number, delay: number, context?: any): void {
-    this.warn(`Retry attempt ${attempt}/${maxRetries} after ${delay}ms`, context);
+  retry(
+    mcpServer: McpServer | null,
+    attempt: number,
+    maxRetries: number,
+    delay: number,
+    context?: unknown
+  ): void {
+    this.warning(mcpServer, `Retry attempt ${attempt}/${maxRetries} after ${delay}ms`, context);
   }
 }
-
+const env = getEnvironment();
 // Create a singleton logger instance
-export const logger = new Logger();
+export const logger = new Logger('document-engine-mcp', env.MCP_TRANSPORT, env.LOG_LEVEL);
 
 // Export the Logger class for testing
 export { Logger };

--- a/test/environment.test.ts
+++ b/test/environment.test.ts
@@ -34,7 +34,7 @@ describe('Environment Validation', () => {
         MAX_RETRIES: 3,
         RETRY_DELAY: 1000,
         MAX_CONNECTIONS: 100,
-        LOG_LEVEL: 'INFO',
+        LOG_LEVEL: 'info',
         MCP_TRANSPORT: 'stdio',
         PORT: 5100,
         MCP_HOST: 'localhost',
@@ -51,7 +51,7 @@ describe('Environment Validation', () => {
         MAX_RETRIES: '5',
         RETRY_DELAY: '2000',
         MAX_CONNECTIONS: '200',
-        LOG_LEVEL: 'DEBUG',
+        LOG_LEVEL: 'debug',
       };
 
       const result = validateEnvironment();
@@ -65,7 +65,7 @@ describe('Environment Validation', () => {
         MAX_RETRIES: 5,
         RETRY_DELAY: 2000,
         MAX_CONNECTIONS: 200,
-        LOG_LEVEL: 'DEBUG',
+        LOG_LEVEL: 'debug',
         MCP_TRANSPORT: 'stdio',
         PORT: 5100,
         MCP_HOST: 'localhost',
@@ -116,14 +116,23 @@ describe('Environment Validation', () => {
       process.env = {
         DOCUMENT_ENGINE_BASE_URL: 'https://api.example.com',
         DOCUMENT_ENGINE_API_AUTH_TOKEN: 'test-token-123',
-        LOG_LEVEL: 'INVALID_LEVEL',
+        LOG_LEVEL: 'invalid_level',
       };
 
       expect(() => validateEnvironment()).toThrow('Invalid enum value');
     });
 
     it('should accept all valid log levels', () => {
-      const validLevels = ['ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG'];
+      const validLevels = [
+        'debug',
+        'info',
+        'notice',
+        'warning',
+        'error',
+        'critical',
+        'alert',
+        'emergency',
+      ];
 
       for (const level of validLevels) {
         process.env = {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
-import { Logger, LogLevel } from '../src/utils/Logger.js';
-
-// Mock the Environment module
-vi.mock('../src/utils/Environment.js', () => ({
-  getEnvironment: vi.fn(),
-}));
+import { Logger } from '../src/utils/Logger.js';
 
 // Mock the MCP server
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
@@ -18,7 +13,6 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
   };
 });
 
-import { getEnvironment, ParsedEnvironment } from '../src/utils/Environment.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 interface MockedMcpServer extends McpServer {
@@ -27,23 +21,6 @@ interface MockedMcpServer extends McpServer {
     sendLoggingMessage: Mock;
   };
 }
-
-const defaultEnvironment: ParsedEnvironment = {
-  DOCUMENT_ENGINE_BASE_URL: 'https://api.example.com',
-  DOCUMENT_ENGINE_API_AUTH_TOKEN: 'mock-token',
-  DASHBOARD_USERNAME: undefined,
-  DASHBOARD_PASSWORD: undefined,
-  CONNECTION_TIMEOUT: 30000,
-  MAX_RETRIES: 3,
-  RETRY_DELAY: 1000,
-  MAX_CONNECTIONS: 100,
-  LOG_LEVEL: 'INFO',
-  MCP_TRANSPORT: 'stdio',
-  PORT: 5100,
-  MCP_HOST: 'localhost',
-  DOCUMENT_ENGINE_POLL_MAX_RETRIES: 30,
-  DOCUMENT_ENGINE_POLL_RETRY_DELAY: 2000,
-};
 
 describe('Logger', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mock objects for testing stream methods
@@ -61,8 +38,6 @@ describe('Logger', () => {
     originalStdout = process.stdout.write;
     process.stderr.write = mockStderr;
     process.stdout.write = mockStdout;
-
-    vi.mocked(getEnvironment).mockReturnValue(defaultEnvironment);
   });
 
   afterEach(() => {
@@ -75,15 +50,11 @@ describe('Logger', () => {
   describe('Log Levels', () => {
     it('should respect log level filtering', () => {
       // Create logger with ERROR level
-      const logger = new Logger('test-service');
-      // Set log level via constructor or skip this test
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private property for testing
-      (logger as any).logLevel = LogLevel.ERROR;
-
-      logger.debug('debug message');
-      logger.info('info message');
-      logger.warn('warn message');
-      logger.error('error message');
+      const logger = new Logger('test-service', 'stdio', 'error');
+      logger.debug(null, 'debug message');
+      logger.info(null, 'info message');
+      logger.warning(null, 'warn message');
+      logger.error(null, 'error message');
 
       // Only error should be logged to stderr, nothing to stdout in stdio mode
       expect(mockStderr).toHaveBeenCalledTimes(1);
@@ -93,42 +64,25 @@ describe('Logger', () => {
     });
 
     it('should log all levels when set to DEBUG in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'DEBUG',
-      });
+      const logger = new Logger('test-service', 'http', 'debug');
 
-      const logger = new Logger('test-service');
-      // Set log level via constructor or skip this test
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private property for testing
-      (logger as any).logLevel = LogLevel.DEBUG;
-
-      logger.debug('debug message');
-      logger.info('info message');
-      logger.warn('warn message');
-      logger.error('error message');
+      logger.debug(null, 'debug message');
+      logger.info(null, 'info message');
+      logger.warning(null, 'warn message');
+      logger.error(null, 'error message');
 
       // Error goes to stderr, others to stdout in HTTP mode
-      expect(mockStderr).toHaveBeenCalledTimes(1);
-      expect(mockStdout).toHaveBeenCalledTimes(3);
+      expect(mockStderr).toHaveBeenCalledTimes(2);
+      expect(mockStdout).toHaveBeenCalledTimes(2);
     });
 
     it('should log all messages to stderr in stdio mode when set to DEBUG', () => {
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'DEBUG',
-      });
+      const logger = new Logger('test-service', 'stdio', 'debug');
 
-      const logger = new Logger('test-service');
-
-      logger.debug('debug message');
-      logger.info('info message');
-      logger.warn('warn message');
-      logger.error('error message');
+      logger.debug(null, 'debug message');
+      logger.info(null, 'info message');
+      logger.warning(null, 'warn message');
+      logger.error(null, 'error message');
 
       // Only error should be logged to stderr, nothing to stdout in stdio mode
       expect(mockStderr).toHaveBeenCalledTimes(4);
@@ -137,183 +91,76 @@ describe('Logger', () => {
   });
 
   describe('Log Format', () => {
-    it('should format log entries as JSON in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.info('test message');
+    it('should format log entries', () => {
+      const logger = new Logger('test-service', 'http');
+      logger.info(null, 'test message');
 
       expect(mockStdout).toHaveBeenCalledTimes(1);
       const logOutput = mockStdout.mock.calls[0][0] as string;
 
-      // Should be valid JSON
-      expect(() => JSON.parse(logOutput)).not.toThrow();
-
-      const parsed = JSON.parse(logOutput);
-      expect(parsed).toHaveProperty('timestamp');
-      expect(parsed).toHaveProperty('level', 'INFO');
-      expect(parsed).toHaveProperty('message', '[test-service] test message');
+      expect(logOutput).toContain('[INFO]');
+      expect(logOutput).toContain('(test-service)');
+      expect(logOutput).toContain(new Date().toISOString().slice(0, -8)); // Don't check seconds
+      expect(logOutput).toContain('test message');
     });
 
-    it('should not write info logs to stdout in stdio mode', () => {
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.info('test message');
-
-      expect(mockStdout).toHaveBeenCalledTimes(0);
-    });
-
-    it('should include context when provided in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
+    it('should include context', () => {
+      const logger = new Logger('test-service', 'http');
       const context = { userId: '123', action: 'test' };
 
-      logger.info('test message', context);
+      logger.info(null, 'test message', context);
 
       expect(mockStdout).toHaveBeenCalledTimes(1);
       const logOutput = mockStdout.mock.calls[0][0] as string;
-      const parsed = JSON.parse(logOutput);
 
-      expect(parsed).toHaveProperty('context', context);
+      expect(logOutput).toContain(JSON.stringify(context));
     });
   });
 
   describe('Convenience Methods', () => {
     it('should format request logs correctly in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.request('GET', '/api/test');
+      const logger = new Logger('test-service', 'http');
+      logger.request(null, 'GET', '/api/test');
 
       expect(mockStdout).toHaveBeenCalledTimes(1);
       const logOutput = mockStdout.mock.calls[0][0] as string;
-      const parsed = JSON.parse(logOutput);
 
-      expect(parsed.level).toBe('INFO');
-      expect(parsed.message).toContain('Request: GET /api/test');
-    });
-
-    it('should not write request logs to stdout in stdio mode', () => {
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.request('GET', '/api/test');
-
-      expect(mockStdout).toHaveBeenCalledTimes(0);
+      expect(logOutput).toContain('INFO');
+      expect(logOutput).toContain('Request: GET /api/test');
     });
 
     it('should format response logs correctly in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.response(200, '/api/test');
+      const logger = new Logger('test-service', 'http');
+      logger.response(null, 200, '/api/test');
 
       expect(mockStdout).toHaveBeenCalledTimes(1);
       const logOutput = mockStdout.mock.calls[0][0] as string;
-      const parsed = JSON.parse(logOutput);
 
-      expect(parsed.level).toBe('INFO');
-      expect(parsed.message).toContain('Response: 200 /api/test');
+      expect(logOutput).toContain('INFO');
+      expect(logOutput).toContain('Response: 200 /api/test');
     });
 
-    it('should log error responses as errors in both modes', () => {
-      // Test in stdio mode first
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.response(500, '/api/test');
+    it('should log error responses as errors in HTTP mode', () => {
+      const logger = new Logger('test-service', 'http');
+      logger.response(null, 500, '/api/test');
 
       expect(mockStderr).toHaveBeenCalledTimes(1);
       expect(mockStdout).toHaveBeenCalledTimes(0);
       const logOutput = mockStderr.mock.calls[0][0] as string;
-      const parsed = JSON.parse(logOutput);
 
-      expect(parsed.level).toBe('ERROR');
-      expect(parsed.message).toContain('Response: 500 /api/test');
-
-      // Reset mocks
-      vi.clearAllMocks();
-
-      // Test in HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
-
-      logger.response(500, '/api/test');
-
-      expect(mockStderr).toHaveBeenCalledTimes(1);
-      expect(mockStdout).toHaveBeenCalledTimes(0);
+      expect(logOutput).toContain('ERROR');
+      expect(logOutput).toContain('Response: 500 /api/test');
     });
 
     it('should format retry logs correctly in HTTP mode', () => {
-      // Mock HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
+      const logger = new Logger('test-service', 'http');
+      logger.retry(null, 2, 3, 1000);
 
-      const logger = new Logger('test-service');
-      logger.retry(2, 3, 1000);
+      expect(mockStderr).toHaveBeenCalledTimes(1);
+      const logOutput = mockStderr.mock.calls[0][0] as string;
 
-      expect(mockStdout).toHaveBeenCalledTimes(1);
-      const logOutput = mockStdout.mock.calls[0][0] as string;
-      const parsed = JSON.parse(logOutput);
-
-      expect(parsed.level).toBe('WARNING');
-      expect(parsed.message).toContain('Retry attempt 2/3 after 1000ms');
-    });
-
-    it('should not write retry logs to stdout in stdio mode', () => {
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
-      const logger = new Logger('test-service');
-      logger.retry(2, 3, 1000);
-
-      expect(mockStdout).toHaveBeenCalledTimes(0);
+      expect(logOutput).toContain('WARNING');
+      expect(logOutput).toContain('Retry attempt 2/3 after 1000ms');
     });
   });
 
@@ -328,6 +175,7 @@ describe('Logger', () => {
         version: '0.0.1',
         capabilities: {
           tools: {},
+          logging: {},
         },
       }) as MockedMcpServer;
       mockMcpServer.server.sendLoggingMessage.mockResolvedValue(undefined);
@@ -337,18 +185,10 @@ describe('Logger', () => {
       // Set server as disconnected
       mockMcpServer.isConnected.mockReturnValue(false);
 
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
       const logger = new Logger('test-service');
-      logger.setMCPServer(mockMcpServer);
 
-      logger.info('info message');
-      logger.error('error message');
+      logger.info(mockMcpServer, 'info message');
+      logger.error(mockMcpServer, 'error message');
 
       // Both logs should go to stderr
       expect(mockStderr).toHaveBeenCalledTimes(2);
@@ -360,21 +200,13 @@ describe('Logger', () => {
       // Set server as connected
       mockMcpServer.isConnected.mockReturnValue(true);
 
-      // Ensure stdio mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'stdio',
-        LOG_LEVEL: 'INFO',
-      });
-
       const logger = new Logger('test-service');
-      logger.setMCPServer(mockMcpServer);
 
-      logger.info('info message');
-      logger.error('error message');
+      logger.info(mockMcpServer, 'info message');
+      logger.error(mockMcpServer, 'error message');
 
       // Only error should go to stderr, info should only go to server
-      expect(mockStderr).toHaveBeenCalledTimes(0);
+      expect(mockStderr).toHaveBeenCalledTimes(2);
       expect(mockStdout).toHaveBeenCalledTimes(0);
       expect(mockMcpServer.server.sendLoggingMessage).toHaveBeenCalledTimes(2);
     });
@@ -383,18 +215,10 @@ describe('Logger', () => {
       // Set server as connected
       mockMcpServer.isConnected.mockReturnValue(true);
 
-      // Set HTTP mode
-      vi.mocked(getEnvironment).mockReturnValue({
-        ...defaultEnvironment,
-        MCP_TRANSPORT: 'http',
-        LOG_LEVEL: 'INFO',
-      });
+      const logger = new Logger('test-service', 'http');
 
-      const logger = new Logger('test-service');
-      logger.setMCPServer(mockMcpServer);
-
-      logger.info('info message');
-      logger.error('error message');
+      logger.info(mockMcpServer, 'info message');
+      logger.error(mockMcpServer, 'error message');
 
       // Error to stderr, info to stdout, both to server
       expect(mockStderr).toHaveBeenCalledTimes(1);

--- a/test/tools/healthCheck.test.ts
+++ b/test/tools/healthCheck.test.ts
@@ -46,7 +46,7 @@ describe('healthCheck', () => {
       MAX_RETRIES: 3,
       RETRY_DELAY: 1000,
       MAX_CONNECTIONS: 100,
-      LOG_LEVEL: 'INFO',
+      LOG_LEVEL: 'info',
       MCP_TRANSPORT: 'stdio',
       PORT: 5100,
       MCP_HOST: 'localhost',
@@ -98,7 +98,7 @@ describe('healthCheck', () => {
       expect(result.markdown).toContain('- **Max Retries**: 3');
       expect(result.markdown).toContain('- **Retry Delay**: 1000ms');
       expect(result.markdown).toContain('- **Max Connections**: 100');
-      expect(result.markdown).toContain('- **Log Level**: INFO');
+      expect(result.markdown).toContain('- **Log Level**: info');
       expect(result.markdown).toContain('- **MCP Transport**: stdio');
     });
 
@@ -113,7 +113,7 @@ describe('healthCheck', () => {
         MAX_RETRIES: 3,
         RETRY_DELAY: 1000,
         MAX_CONNECTIONS: 100,
-        LOG_LEVEL: 'INFO',
+        LOG_LEVEL: 'info',
         MCP_TRANSPORT: 'http',
         PORT: 5100,
         MCP_HOST: 'localhost',
@@ -190,7 +190,7 @@ describe('healthCheck', () => {
         MAX_RETRIES: 3,
         RETRY_DELAY: 1000,
         MAX_CONNECTIONS: 100,
-        LOG_LEVEL: 'INFO',
+        LOG_LEVEL: 'info',
         MCP_TRANSPORT: 'stdio',
         PORT: 5100,
         MCP_HOST: 'localhost',
@@ -211,7 +211,7 @@ describe('healthCheck', () => {
         MAX_RETRIES: 3,
         RETRY_DELAY: 1000,
         MAX_CONNECTIONS: 100,
-        LOG_LEVEL: 'INFO',
+        LOG_LEVEL: 'info',
         MCP_TRANSPORT: 'stdio',
         PORT: 5100,
         MCP_HOST: 'localhost',


### PR DESCRIPTION
- Standardize `env.LOG_LEVEL` to match the MCP log levels
- Update the `Logger` class to no longer keeping track of an `MCPServer` instance. This is because in a HTTP transport set up, there are multiple instances of `MCPServer` created for each session (see `src/index.ts` line 219). The Logger class is meant to be used as a singleton hence we will have some issue where the Logger class mistakenly send out logging to the wrong session. To fix this the Logger class now requires passing the `MCPServer` in the parameter. 
- When logging outside of the `MCPServer` context, or when you want to log things for the server without sending the log to the client, you can pass in `null` instead of an `MCPServer`