### PR TITLE
chore: add smithery.yaml for Smithery distribution

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -23,6 +23,12 @@ startCommand:
       mcpServerUrl:
         type: string
         description: Optional MCP callback/server URL
+      dashboardUsername:
+        type: string
+        description: Optional dashboard username
+      dashboardPassword:
+        type: string
+        description: Optional dashboard password
   commandFunction: |-
     (config) => ({
       command: 'node',
@@ -31,6 +37,8 @@ startCommand:
         DOCUMENT_ENGINE_BASE_URL: config.documentEngineBaseUrl,
         DOCUMENT_ENGINE_API_AUTH_TOKEN: config.documentEngineApiAuthToken,
         DOCUMENT_ENGINE_API_BASE_URL: config.documentEngineApiBaseUrl,
-        MCP_SERVER_URL: config.mcpServerUrl
+        MCP_SERVER_URL: config.mcpServerUrl,
+        ...(config.dashboardUsername ? { DASHBOARD_USERNAME: config.dashboardUsername } : {}),
+        ...(config.dashboardPassword ? { DASHBOARD_PASSWORD: config.dashboardPassword } : {})
       }
     })

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,8 +1,5 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
 
-build:
-  dockerBuildPath: .
-
 startCommand:
   type: stdio
   configSchema:
@@ -18,12 +15,6 @@ startCommand:
         type: string
         writeOnly: true
         description: API auth token configured for Document Engine
-      documentEngineApiBaseUrl:
-        type: string
-        description: Optional override for API base URL
-      mcpServerUrl:
-        type: string
-        description: Optional MCP callback/server URL
       dashboardUsername:
         type: string
         description: Optional dashboard username; must be provided together with dashboardPassword to enable the dashboard
@@ -38,13 +29,11 @@ startCommand:
         - dashboardUsername
   commandFunction: |-
     (config) => ({
-      command: 'node',
-      args: ['/app/dist/index.js'],
+      command: 'npx',
+      args: ['-y', '@nutrient-sdk/document-engine-mcp-server'],
       env: {
         DOCUMENT_ENGINE_BASE_URL: config.documentEngineBaseUrl,
         DOCUMENT_ENGINE_API_AUTH_TOKEN: config.documentEngineApiAuthToken,
-        DOCUMENT_ENGINE_API_BASE_URL: config.documentEngineApiBaseUrl,
-        MCP_SERVER_URL: config.mcpServerUrl,
         ...(config.dashboardUsername && config.dashboardPassword
           ? {
               DASHBOARD_USERNAME: config.dashboardUsername,

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -13,11 +13,10 @@ startCommand:
     properties:
       documentEngineBaseUrl:
         type: string
-        format: uri
-        pattern: '^https?://'
         description: Base URL for Nutrient Document Engine (e.g. http://localhost:5000)
       documentEngineApiAuthToken:
         type: string
+        writeOnly: true
         description: API auth token configured for Document Engine
       documentEngineApiBaseUrl:
         type: string
@@ -27,10 +26,16 @@ startCommand:
         description: Optional MCP callback/server URL
       dashboardUsername:
         type: string
-        description: Optional dashboard username
+        description: Optional dashboard username; must be provided together with dashboardPassword to enable the dashboard
       dashboardPassword:
         type: string
-        description: Optional dashboard password
+        writeOnly: true
+        description: Optional dashboard password; must be provided together with dashboardUsername to enable the dashboard
+    dependentRequired:
+      dashboardUsername:
+        - dashboardPassword
+      dashboardPassword:
+        - dashboardUsername
   commandFunction: |-
     (config) => ({
       command: 'node',
@@ -40,7 +45,11 @@ startCommand:
         DOCUMENT_ENGINE_API_AUTH_TOKEN: config.documentEngineApiAuthToken,
         DOCUMENT_ENGINE_API_BASE_URL: config.documentEngineApiBaseUrl,
         MCP_SERVER_URL: config.mcpServerUrl,
-        ...(config.dashboardUsername ? { DASHBOARD_USERNAME: config.dashboardUsername } : {}),
-        ...(config.dashboardPassword ? { DASHBOARD_PASSWORD: config.dashboardPassword } : {})
+        ...(config.dashboardUsername && config.dashboardPassword
+          ? {
+              DASHBOARD_USERNAME: config.dashboardUsername,
+              DASHBOARD_PASSWORD: config.dashboardPassword
+            }
+          : {})
       }
     })

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -13,6 +13,8 @@ startCommand:
     properties:
       documentEngineBaseUrl:
         type: string
+        format: uri
+        pattern: '^https?://'
         description: Base URL for Nutrient Document Engine (e.g. http://localhost:5000)
       documentEngineApiAuthToken:
         type: string


### PR DESCRIPTION
## Why
This improves discoverability and one-command install ergonomics for MCP clients that support Smithery manifests.

## Summary
- Add `smithery.yaml` so the server can be listed/distributed via Smithery
- Use `npx -y @nutrient-sdk/document-engine-mcp-server` for stdio transport — no Docker needed for Smithery distribution
- Define required config (`documentEngineBaseUrl`, `documentEngineApiAuthToken`)
- Expose optional dashboard credentials with `dependentRequired` to enforce both-or-neither
- Mark auth token and dashboard password as `writeOnly` so UI tooling masks them
- Remove dead config vars (`documentEngineApiBaseUrl`, `mcpServerUrl`) that the server never reads
- Remove `build` section — the Dockerfile is for self-hosted HTTP deployments, not Smithery distribution