### PR TITLE
Add MCP registry metadata (server.json + mcpName)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nutrient-sdk/document-engine-mcp-server",
   "version": "0.0.1",
+  "mcpName": "io.github.PSPDFKit/nutrient-document-engine-mcp-server",
   "description": "MCP server for Nutrient Document Engine",
   "license": "MIT",
   "author": "Nutrient (https://www.nutrient.io)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nutrient-sdk/document-engine-mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "mcpName": "io.github.PSPDFKit/nutrient-document-engine-mcp-server",
   "description": "MCP server for Nutrient Document Engine",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.PSPDFKit/nutrient-document-engine-mcp-server",
+  "title": "Nutrient Document Engine MCP Server",
+  "description": "Self-hosted MCP server for Nutrient Document Engine: on-premises document processing with natural-language control, designed for HIPAA, SOC 2, and GDPR compliance.",
+  "version": "0.0.1",
+  "repository": {
+    "url": "https://github.com/PSPDFKit/nutrient-document-engine-mcp-server",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@nutrient-sdk/document-engine-mcp-server",
+      "version": "0.0.1",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "DOCUMENT_ENGINE_BASE_URL",
+          "description": "Base URL of your Nutrient Document Engine instance (e.g. http://localhost:5000).",
+          "isRequired": true,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "DOCUMENT_ENGINE_API_AUTH_TOKEN",
+          "description": "API auth token for your Document Engine instance.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.PSPDFKit/nutrient-document-engine-mcp-server",
   "title": "Nutrient Document Engine MCP Server",
   "description": "Self-hosted MCP server for Nutrient Document Engine: on-premises document processing with natural-language control, designed for HIPAA, SOC 2, and GDPR compliance.",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "repository": {
     "url": "https://github.com/PSPDFKit/nutrient-document-engine-mcp-server",
     "source": "github"
@@ -12,8 +12,10 @@
     {
       "registryType": "npm",
       "identifier": "@nutrient-sdk/document-engine-mcp-server",
-      "version": "0.0.1",
-      "transport": { "type": "stdio" },
+      "version": "0.0.3",
+      "transport": {
+        "type": "stdio"
+      },
       "environmentVariables": [
         {
           "name": "DOCUMENT_ENGINE_BASE_URL",
@@ -27,6 +29,34 @@
           "description": "API auth token for your Document Engine instance.",
           "isRequired": true,
           "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "DASHBOARD_USERNAME",
+          "description": "Optional: enables the local status dashboard (Basic auth username).",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "DASHBOARD_PASSWORD",
+          "description": "Optional: local status dashboard password.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Optional log level (default info).",
+          "isRequired": false,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Optional transport, stdio (default) or http; http binds loopback unless configured otherwise.",
+          "isRequired": false,
+          "isSecret": false,
           "format": "string"
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `server.json` at the repo root and an `mcpName` field to `package.json`, the two things required to publish this server to the **official MCP registry** (registry.modelcontextprotocol.io).
- Namespace: `io.github.PSPDFKit/nutrient-document-engine-mcp-server` (GitHub-auth).
- **No runtime code changed.** Metadata only.

## Why
Publishing once to the official registry cascades automatically to Glama, PulseMCP, and mcp.so. Today this server has no `server.json`, so it isn't in the official registry.

## Before publishing (maintainer checklist)
```bash
brew install mcp-publisher
mcp-publisher login github        # needs push access to PSPDFKit
mcp-publisher publish --dry-run
mcp-publisher publish
```
Please confirm at dry-run time:
- [ ] **Version alignment** — `server.json` and `package.json` are both `0.0.1`, but npm latest is `0.0.2`. Reconcile these (bump repo to the version you'll publish) before publishing; the registry validates that `server.json` version matches the published npm version.
- [ ] `$schema` date is current (dry-run flags if stale).
- [ ] env vars complete — I included `DOCUMENT_ENGINE_BASE_URL` (required) and `DOCUMENT_ENGINE_API_AUTH_TOKEN` (required/secret). `ACTIVATION_KEY` is a Document Engine deployment setting, not an MCP client env, so it's intentionally excluded — add it if the server itself reads it.

## Test plan
- [x] `package.json` and `server.json` both parse as valid JSON.
- [x] Diff is metadata-only (package.json +1 line, new server.json).
- [ ] `mcp-publisher publish --dry-run` passes (run by a maintainer).